### PR TITLE
Invoke preprocessor, rename include

### DIFF
--- a/examples/AnimateAccel/AnimateAccel.cpp
+++ b/examples/AnimateAccel/AnimateAccel.cpp
@@ -1,5 +1,4 @@
-#pragma SPARK_NO_PREPROCESSOR
-#include "application.h"
+#include "Particle.h"
 #include "BetterPhotonButton.h"
 
 SYSTEM_THREAD(ENABLED);

--- a/examples/Animations/Animations.cpp
+++ b/examples/Animations/Animations.cpp
@@ -1,5 +1,4 @@
-#pragma SPARK_NO_PREPROCESSOR
-#include "application.h"
+#include "Particle.h"
 #include "BetterPhotonButton.h"
 
 SYSTEM_THREAD(ENABLED);

--- a/examples/Incrementor/Incrementor.cpp
+++ b/examples/Incrementor/Incrementor.cpp
@@ -1,5 +1,4 @@
-#pragma SPARK_NO_PREPROCESSOR
-#include "application.h"
+#include "Particle.h"
 #include "BetterPhotonButton.h"
 
 SYSTEM_THREAD(ENABLED);

--- a/examples/PlaySongs/PlaySongs.cpp
+++ b/examples/PlaySongs/PlaySongs.cpp
@@ -1,5 +1,4 @@
-#pragma SPARK_NO_PREPROCESSOR
-#include "application.h"
+#include "Particle.h"
 #include "BetterPhotonButton.h"
 
 SYSTEM_THREAD(ENABLED);

--- a/examples/SerialTesting/SerialTesting.cpp
+++ b/examples/SerialTesting/SerialTesting.cpp
@@ -1,5 +1,4 @@
-#pragma SPARK_NO_PREPROCESSOR
-#include "application.h"
+#include "Particle.h"
 #include "BetterPhotonButton.h"
 
 /* print out the button and its state */

--- a/examples/SimpleRainbow/SimpleRainbow.cpp
+++ b/examples/SimpleRainbow/SimpleRainbow.cpp
@@ -1,5 +1,4 @@
-#pragma SPARK_NO_PREPROCESSOR
-#include "application.h"
+#include "Particle.h"
 #include "BetterPhotonButton.h"
 
 BetterPhotonButton bb = BetterPhotonButton();

--- a/examples/ToneTest/ToneTest.cpp
+++ b/examples/ToneTest/ToneTest.cpp
@@ -1,5 +1,4 @@
-#pragma SPARK_NO_PREPROCESSOR
-#include "application.h"
+#include "Particle.h"
 #include "BetterPhotonButton.h"
 
 SYSTEM_THREAD(ENABLED);

--- a/examples/Whites/Whites.cpp
+++ b/examples/Whites/Whites.cpp
@@ -1,5 +1,4 @@
-#pragma SPARK_NO_PREPROCESSOR
-#include "application.h"
+#include "Particle.h"
 #include "BetterPhotonButton.h"
 
 SYSTEM_THREAD(ENABLED);


### PR DESCRIPTION
Thanks for updating your library!

I recently made to the preprocessor that makes it better behaved with custom types. All your examples compile fine without the no preprocessor macro.

Also we'd like to encourage people to use "Particle.h" instead of "application.h" in their examples.